### PR TITLE
Fix for query params in filesaver.directive.ts

### DIFF
--- a/lib/src/filesaver.directive.ts
+++ b/lib/src/filesaver.directive.ts
@@ -36,11 +36,11 @@ export class FileSaverDirective {
     }
     let req = this.http;
     if (!req) {
-      const params = new HttpParams();
+      let params = new HttpParams();
       const query = this.query || {};
       // tslint:disable-next-line:forin
       for (const item in query) {
-        params.set(item, query[item]);
+        params = params.set(item, query[item]);
       }
 
       req = this.httpClient.request(this.method, this.url, {


### PR DESCRIPTION
HTTP client works with an immutable request object(https://stackoverflow.com/questions/45459532/why-httpparams-doesnt-work-in-multiple-line-in-angular-4-3/45459672#45459672) which means that query params are not copied to the request params. I fixed it by assignation the returned instance of set method back to the params instance